### PR TITLE
bump version ahead of v1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 1.5.0
+No changes, bump version number to avoid confusion with versioning in original project.
+
 ## Release 1.0.1
 Minor bugfix release to have parameter 'version' before it's used in 'source_base_url'.
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "veepshosting-oauth2_proxy",
-  "version": "1.0.1",
+  "version": "1.5.0",
   "author": "Grant Davies <grant at veepshosting dot com>",
   "summary": "manages the oauth2_proxy reverse proxy with oauth authentication",
   "license": "Apache-2.0",


### PR DESCRIPTION
last version in jhoblitt/puppet-oauth2_proxy is v1.4.2, and these tags have been kept in the fork.  jumping to 1.5.0 avoids confusion caused by rolling back/reusing version tags.