### PR TITLE
control cleanup of tarball

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,8 @@
 #   Default: "https://github.com/oauth2-proxy/oauth2-proxy/releases/download/v${version}"
 # @param tarball_name The name of the tarball
 #   Default: "oauth2-proxy-v${version}.linux-amd64.tar.gz"
+# @param delete_tarball Whether to remove download after extraction.  If true, will download on every run.
+#   Default: false
 # @param provider Provider to use
 #   Default: 'systemd'
 # @param shell Shell to use for oauth2 user
@@ -38,6 +40,7 @@ class oauth2_proxy (
   String           $version         = '7.3.0',
   Stdlib::HTTPUrl  $source_base_url = "https://github.com/oauth2-proxy/oauth2-proxy/releases/download/v${version}",
   String           $tarball_name    = "oauth2-proxy-v${version}.linux-amd64.tar.gz",
+  Boolean          $delete_tarball  = false,
   String           $user            = 'oauth2',
 ) {
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,14 +9,17 @@ class oauth2_proxy::install {
   $base    = regsubst($oauth2_proxy::tarball_name, '(\w+).tar.gz$', '\1')
 
   include ::archive
+  $tarfile = "${oauth2_proxy::install_root}/download/${oauth2_proxy::tarball_name}"
   archive { $oauth2_proxy::tarball_name:
     ensure       => present,
     source       => "${oauth2_proxy::source_base_url}/${oauth2_proxy::tarball_name}",
-    path         => "${oauth2_proxy::install_root}/${oauth2_proxy::tarball_name}",
+    path         => $tarfile,
     extract      => true,
     extract_path => $oauth2_proxy::install_root,
     user         => $oauth2_proxy::user,
+    cleanup      => $oauth2_proxy::delete_tarball,
   }
+  ~> file { $tarfile: }
 
   file {
     default:
@@ -26,6 +29,12 @@ class oauth2_proxy::install {
       ;
     $oauth2_proxy::install_root:
       ensure => directory,
+      ;
+    "${oauth2_proxy::install_root}/download":
+      ensure  => directory,
+      # Even with delete_tarball true, only keep current tarball in this directory
+      recurse => true,
+      purge   => true,
       ;
     "${oauth2_proxy::install_root}/bin":
       ensure => link,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -18,32 +18,25 @@ class oauth2_proxy::install {
     user         => $oauth2_proxy::user,
   }
 
-  file { $oauth2_proxy::install_root:
-    ensure => directory,
-    owner  => $oauth2_proxy::user,
-    group  => $oauth2_proxy::group,
-    mode   => '0755',
-  }
-
-  file { "${oauth2_proxy::install_root}/bin":
-    ensure => link,
-    owner  => $oauth2_proxy::user,
-    group  => $oauth2_proxy::group,
-    target => "${oauth2_proxy::install_root}/${base}",
-  }
-
-  file { '/etc/oauth2_proxy':
-    ensure => directory,
-    owner  => $oauth2_proxy::user,
-    group  => $oauth2_proxy::group,
-    mode   => '0755',
-  }
-
-  file { '/var/log/oauth2_proxy':
-    ensure => directory,
-    owner  => $oauth2_proxy::user,
-    group  => $oauth2_proxy::group,
-    mode   => '0775',
+  file {
+    default:
+      owner  => $oauth2_proxy::user,
+      group  => $oauth2_proxy::group,
+      mode   => '0755',
+      ;
+    $oauth2_proxy::install_root:
+      ensure => directory,
+      ;
+    "${oauth2_proxy::install_root}/bin":
+      ensure => link,
+      target => "${oauth2_proxy::install_root}/${base}",
+      ;
+    '/etc/oauth2_proxy':
+      ensure => directory,
+      ;
+    '/var/log/oauth2_proxy':
+      ensure => directory,
+      mode   => '0775',
   }
 
   case $oauth2_proxy::provider {


### PR DESCRIPTION
It seems redundant to download the archive file on each Puppet run, so this patch allows this bit of `archive` behaviour to be controlled.  It defaults to keeping the latest download around.
