### PR TITLE
Add support for ARM architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 1.1.0
+Add support for ARM architecture
+
 ## Release 1.0.1
 Minor bugfix release to have parameter 'version' before it's used in 'source_base_url'.
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,18 +1,22 @@
 # @summary Class to install and configure an oauth2_proxy
 #   This class should be considered private.
 #
-class oauth2_proxy::install {
+# @param tarball_name The name of the tarball to download and install
+#
+class oauth2_proxy::install (
+  String $tarball_name
+) {
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  $base    = regsubst($oauth2_proxy::tarball_name, '(\w+).tar.gz$', '\1')
+  $base    = regsubst($tarball_name, '(\w+).tar.gz$', '\1')
 
   include ::archive
-  archive { $oauth2_proxy::tarball_name:
+  archive { $tarball_name:
     ensure       => present,
-    source       => "${oauth2_proxy::source_base_url}/${oauth2_proxy::tarball_name}",
-    path         => "${oauth2_proxy::install_root}/${oauth2_proxy::tarball_name}",
+    source       => "${oauth2_proxy::source_base_url}/${tarball_name}",
+    path         => "${oauth2_proxy::install_root}/${tarball_name}",
     extract      => true,
     extract_path => $oauth2_proxy::install_root,
     user         => $oauth2_proxy::user,


### PR DESCRIPTION
OAuth2 Proxy provides also pre-compiled packages for ARM (see https://github.com/oauth2-proxy/oauth2-proxy/releases). In this PR I would like to add the ARM support also for the puppet module